### PR TITLE
feat: make CCO endpoint fully configurable in e2e tests

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -103,14 +103,32 @@ Each test creates a temporary git repository with a unique name (e.g., `zap-123`
 The test script uses these environment variables:
 
 - `CCO_PORT` - Port where CCO-MCP is running (default: 8660)
+- `CCO_ENDPOINT` - Full endpoint URL for CCO-MCP (default: `http://host.docker.internal:${CCO_PORT}/mcp`)
+
+### Configuration Examples
+
+```bash
+# Default (local development)
+./run-test.sh
+
+# Custom local port
+CCO_PORT=8080 ./run-test.sh
+
+# External endpoint (e.g., Cloud Run deployment)
+CCO_ENDPOINT=https://auth-server-cco-mcp-2aylmcmupq-uw.a.run.app/mcp ./run-test.sh
+
+# Any custom endpoint
+CCO_ENDPOINT=https://my-cco-server.example.com/mcp ./run-test.sh
+```
 
 ## MCP Server Configuration
 
 Each test repo is configured with:
 
-- **cco**: HTTP server at `http://host.docker.internal:8660/mcp` for approvals
-- **git**: Standard MCP git server for repository operations
+- **cco**: HTTP server at the configured `CCO_ENDPOINT` for approvals
 - **context7**: SSE server for documentation lookups
+
+The CCO endpoint defaults to `http://host.docker.internal:8660/mcp` for local development but can be overridden to test against external deployments.
 
 ## Debugging
 


### PR DESCRIPTION
## Summary

This PR makes the CCO endpoint fully configurable in the e2e test script, allowing tests to run against both local and external deployments (e.g., Cloud Run).

## Problem

Previously, the e2e test script only supported configuring the port (`CCO_PORT`) and was hardcoded to use `http://host.docker.internal:${CCO_PORT}/mcp`. This made it impossible to test against external deployments.

## Solution

- Added `CCO_ENDPOINT` environment variable that accepts a full endpoint URL
- Maintained backward compatibility with `CCO_PORT` for existing workflows
- Updated health check logic to work with any endpoint format
- Enhanced error messages to show the actual endpoint being used

## Changes

- **`run-test.sh`**:
  - Added `CCO_ENDPOINT` configuration with default fallback to existing behavior
  - Updated `check_cco_running()` to extract base URL from endpoint
  - Modified MCP configuration to use the full endpoint
  - Improved status messages to show endpoint instead of just port

- **`README.md`**:
  - Added documentation for the new `CCO_ENDPOINT` variable
  - Provided configuration examples for different use cases
  - Updated MCP server configuration section

## Usage Examples

```bash
# Default local development (unchanged)
./run-test.sh

# Custom local port (backward compatible)
CCO_PORT=8080 ./run-test.sh

# External deployment
CCO_ENDPOINT=https://cco-mcp.toolprint.ai/mcp ./run-test.sh
```

## Testing

- [x] Verified syntax with `bash -n run-test.sh`
- [x] Tested endpoint parsing logic
- [x] Confirmed backward compatibility with `CCO_PORT`
- [x] Documentation updated with clear examples

## Impact

- No breaking changes - existing workflows continue to work
- Enables testing against production deployments
- Improves flexibility for CI/CD pipelines

🤖 Generated with [Claude Code](https://claude.ai/code)